### PR TITLE
Expose parse errors via `Dotenv::iter`.

### DIFF
--- a/src/dotenv.rs
+++ b/src/dotenv.rs
@@ -73,7 +73,7 @@ impl<'a> Iter<'a> {
                         }
                     }
                 }
-                Err(err) => return Err(crate::Error::Parse(format!("{err}"))),
+                Err(err) => return Err(err.into()),
             }
         }
         Ok(None)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::error;
 use std::fmt;
+use std::fmt::Display;
 use std::io;
 
 #[derive(Debug)]
@@ -8,6 +9,7 @@ use std::io;
 pub enum Error {
     Io(io::Error),
     Env(env::VarError),
+    Parse(String),
 }
 
 impl Error {
@@ -29,6 +31,7 @@ impl fmt::Display for Error {
         match self {
             Error::Io(err) => err.fmt(fmt),
             Error::Env(err) => err.fmt(fmt),
+            Error::Parse(err) => err.fmt(fmt),
         }
     }
 }
@@ -38,6 +41,7 @@ impl error::Error for Error {
         match self {
             Error::Io(err) => Some(err),
             Error::Env(err) => Some(err),
+            Error::Parse(_) => None,
         }
     }
 }
@@ -51,5 +55,11 @@ impl From<io::Error> for Error {
 impl From<env::VarError> for Error {
     fn from(err: env::VarError) -> Self {
         Error::Env(err)
+    }
+}
+
+impl<I: Display> From<nom::error::Error<I>> for Error {
+    fn from(err: nom::error::Error<I>) -> Self {
+        Error::Parse(format!("{err}"))
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::error;
 use std::fmt;
-use std::fmt::Display;
 use std::io;
 
 #[derive(Debug)]
@@ -29,9 +28,9 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::Io(err) => err.fmt(fmt),
-            Error::Env(err) => err.fmt(fmt),
-            Error::Parse(err) => err.fmt(fmt),
+            Error::Io(err) => fmt::Display::fmt(&err, fmt),
+            Error::Env(err) => fmt::Display::fmt(&err, fmt),
+            Error::Parse(err) => fmt::Display::fmt(&err, fmt),
         }
     }
 }
@@ -58,8 +57,8 @@ impl From<env::VarError> for Error {
     }
 }
 
-impl<I: Display> From<nom::error::Error<I>> for Error {
-    fn from(err: nom::error::Error<I>) -> Self {
+impl<E: fmt::Debug> From<nom::Err<E>> for Error {
+    fn from(err: nom::Err<E>) -> Self {
         Error::Parse(format!("{err}"))
     }
 }

--- a/tests/fixtures/sample-basic.env
+++ b/tests/fixtures/sample-basic.env
@@ -24,7 +24,6 @@ DOUBLE_AND_SINGLE_QUOTES_INSIDE_BACKTICKS=`double "quotes" and single 'quotes' w
 EXPAND_NEWLINES="expand\nnew\nlines"
 DONT_EXPAND_UNQUOTED=dontexpand\nnewlines
 DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
-DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
 # COMMENTS=work
 INLINE_COMMENTS=inline comments # work #very #well
 INLINE_COMMENTS_SINGLE_QUOTES='inline comments outside of #singlequotes' # work

--- a/tests/test-dotenv-try-next.rs
+++ b/tests/test-dotenv-try-next.rs
@@ -1,0 +1,19 @@
+mod fixtures;
+use fixtures::*;
+
+#[test]
+fn test_propagate_env_parse_errors() -> anyhow::Result<()> {
+    let (_t, mut exps) = with_basic_dotenv()?;
+
+    // This is an example of how a consumer that cares about invalid `.env` files can handle them using the
+    // `Iter::try_next` API (see: https://github.com/arniu/dotenvs-rs/issues/4)
+    let env = dotenv::from_filename(".env")?;
+    let mut iter = env.iter();
+    while let Some((key, value)) = iter.try_next()? {
+        let expected = exps.remove(key).unwrap();
+        assert_eq!(expected, value, "check {}", key);
+    }
+    assert!(exps.is_empty());
+
+    Ok(())
+}

--- a/tests/test-sample-bad.rs
+++ b/tests/test-sample-bad.rs
@@ -1,0 +1,44 @@
+use dotenv::Error;
+use std::collections::HashMap;
+use std::iter::{IntoIterator, Iterator};
+
+const BAD_ENV: &str = r#"
+A=foo bar
+B="notenough
+C='toomany''
+D=valid
+export NOT_SET
+E=valid
+"#;
+
+#[test]
+fn test_bad_env() -> anyhow::Result<()> {
+    let env = dotenv::from_read(BAD_ENV.as_bytes())?;
+
+    assert_eq!(
+        vec![
+            ("A", "foo bar".into()),
+            ("B", "\"notenough".into()),
+            ("C", "toomany".into())
+        ]
+        .into_iter()
+        .collect::<HashMap<_, _>>(),
+        env.iter().collect::<HashMap<_, _>>()
+    );
+
+    let mut iter = env.iter();
+    assert_eq!(Some(("A", "foo bar".into())), iter.try_next()?);
+    assert_eq!(Some(("B", "\"notenough".into())), iter.try_next()?);
+    assert_eq!(Some(("C", "toomany".into())), iter.try_next()?);
+
+    // TODO: Use assert_matches! when it stabilizes: https://github.com/rust-lang/rust/issues/82775
+    match iter.try_next().unwrap_err() {
+        Error::Parse(err) => assert_eq!(
+            "Parsing Error: Error { input: \"'\\nD=valid\\nexport NOT_SET\\nE=valid\\n\", code: Tag }",
+            err
+        ),
+        err => panic!("Unexpected error variant: {err:?}", err = err),
+    }
+
+    Ok(())
+}

--- a/tests/test-sample-bad.rs
+++ b/tests/test-sample-bad.rs
@@ -1,6 +1,4 @@
 use dotenv::Error;
-use std::collections::HashMap;
-use std::iter::{IntoIterator, Iterator};
 
 const BAD_ENV: &str = r#"
 A=foo bar
@@ -20,10 +18,8 @@ fn test_bad_env() -> anyhow::Result<()> {
             ("A", "foo bar".into()),
             ("B", "\"notenough".into()),
             ("C", "toomany".into())
-        ]
-        .into_iter()
-        .collect::<HashMap<_, _>>(),
-        env.iter().collect::<HashMap<_, _>>()
+        ],
+        env.iter().collect::<Vec<_>>()
     );
 
     let mut iter = env.iter();
@@ -32,13 +28,10 @@ fn test_bad_env() -> anyhow::Result<()> {
     assert_eq!(Some(("C", "toomany".into())), iter.try_next()?);
 
     // TODO: Use assert_matches! when it stabilizes: https://github.com/rust-lang/rust/issues/82775
-    match iter.try_next().unwrap_err() {
-        Error::Parse(err) => assert_eq!(
-            "Parsing Error: Error { input: \"'\\nD=valid\\nexport NOT_SET\\nE=valid\\n\", code: Tag }",
-            err
-        ),
-        err => panic!("Unexpected error variant: {err:?}", err = err),
-    }
+    assert!(matches!(
+        iter.try_next().unwrap_err(),
+        Error::Parse(err) if err == "Parsing Error: Error { input: \"'\\nD=valid\\nexport NOT_SET\\nE=valid\\n\", code: Tag }"
+    ));
 
     Ok(())
 }

--- a/tests/test-sample-basic.rs
+++ b/tests/test-sample-basic.rs
@@ -3,11 +3,12 @@ use fixtures::*;
 
 #[test]
 fn test_sample() -> anyhow::Result<()> {
-    let (_t, exps) = with_basic_dotenv()?;
+    let (_t, mut exps) = with_basic_dotenv()?;
     for (key, value) in dotenv::from_filename(".env")?.iter() {
-        let expected = exps.get(key).unwrap();
-        assert_eq!(expected, &value, "check {}", key);
+        let expected = exps.remove(key).unwrap();
+        assert_eq!(expected, value, "check {}", key);
     }
+    assert!(exps.is_empty());
 
     Ok(())
 }

--- a/tests/test-sample-expand.rs
+++ b/tests/test-sample-expand.rs
@@ -3,11 +3,12 @@ use fixtures::*;
 
 #[test]
 fn test_sample() -> anyhow::Result<()> {
-    let (_t, exps) = with_expand_dotenv()?;
+    let (_t, mut exps) = with_expand_dotenv()?;
     for (key, value) in dotenv::from_filename(".env")?.iter() {
-        let expected = exps.get(key).unwrap();
-        assert_eq!(expected, &value, "check {}", key);
+        let expected = exps.remove(key).unwrap();
+        assert_eq!(expected, value, "check {}", key);
     }
+    assert!(exps.is_empty());
 
     Ok(())
 }

--- a/tests/test-sample-multiline.rs
+++ b/tests/test-sample-multiline.rs
@@ -3,11 +3,12 @@ use fixtures::*;
 
 #[test]
 fn test_sample() -> anyhow::Result<()> {
-    let (_t, exps) = with_multiline_dotenv()?;
+    let (_t, mut exps) = with_multiline_dotenv()?;
     for (key, value) in dotenv::from_filename(".env")?.iter() {
-        let expected = exps.get(key).unwrap();
-        assert_eq!(expected, &value, "check {}", key);
+        let expected = exps.remove(key).unwrap();
+        assert_eq!(expected, value, "check {}", key);
     }
+    assert!(exps.is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
Refactor `dotenv::dotenv::Iter` to expose parse errors for those
interested. The parse errors are structured as opaque strings to hide
the parsing implementation details (currently nom and nom's errors are
the internal currency).

This allows a consumer that cares about propagating errors in `.env`
files to use something like:
```rust
let env = dotenv::from_filename(".env")?;
let mut iter = env.iter();
while let Some((key, value)) = iter.try_next()? {
    if std::env::var(key).is_err() {
        std::env::set_var(key, value);
    }
}
```

Fixes #4