### PR TITLE
refactor: align parser naming with ABNF spec

### DIFF
--- a/spec/dotenv.abnf
+++ b/spec/dotenv.abnf
@@ -25,7 +25,7 @@
 
 dotenv-file    = *( blank-line / comment-line / kv-line )
 
-kv-line        = [ export ] key sep [ value ] [ inline-comment ]
+kv-line        = [ export ] key separator [ value ] [ inline-comment ]
                  line-ending
 
 blank-line     = line-ending
@@ -82,20 +82,20 @@ DIGIT          = %x30-39               ; 0-9
 ; 6.  Separator
 ; ============================================================
 
-sep            = *WSP "=" *WSP
+separator      = *WSP "=" *WSP
 
 ; ============================================================
 ; 7.  Value
 ; ============================================================
 
-value          = single-valued / double-valued / backtick-val / unquoted-valued
+value          = single-quoted / double-quoted / backtick-quoted / unquoted
 
 ; If no value is present (end-of-line after separator), the value
 ; is the empty string.  e.g.  EMPTY=
 
 ; ---- 7.1  Single-Quoted — literal, no substitution ----
 
-single-valued  = "'" *single-char "'"
+single-quoted  = "'" *single-char "'"
 single-char    = %x00-26 / %x28-10FFFF
                ; any character except "'" (%x27)
                ; includes newlines — supports multi-line values
@@ -104,12 +104,12 @@ single-char    = %x00-26 / %x28-10FFFF
 
 ; ---- 7.2  Double-Quoted — substitution enabled, escapes ----
 
-double-valued  = DQUOTE *double-char DQUOTE
-double-char    = escape-seq
+double-quoted  = DQUOTE *double-char DQUOTE
+double-char    = escape-sequence
                / substitution
                / double-literal
 
-escape-seq     = %x5C ( "n" / "r" / "\" / "$" )
+escape-sequence     = %x5C ( "n" / "r" / "\" / "$" )
                ; \n → LF  \r → CR  \\ → \  \$ → $
 
 double-literal = %x00-21 / %x23 / %x25-5B / %x5D-10FFFF
@@ -123,7 +123,7 @@ DQUOTE         = %x22    ; double quote character
 
 ; ---- 7.3  Backtick-Quoted — literal, no substitution ----
 
-backtick-val   = "`" *backtick-char "`"
+backtick-quoted   = "`" *backtick-char "`"
 backtick-char  = %x00-5F / %x61-10FFFF
                ; any character except "`" (%x60)
                ; includes newlines — supports multi-line values
@@ -132,7 +132,7 @@ backtick-char  = %x00-5F / %x61-10FFFF
 
 ; ---- 7.4  Unquoted — substitution enabled, single-line ----
 
-unquoted-valued = 1*unquoted-char
+unquoted = 1*unquoted-char
 
 unquoted-char  = unquoted-escape
                / substitution
@@ -191,8 +191,8 @@ fallback-char  = %x00-23 / %x25-7A / %x7C / %x7E-10FFFF
 
 ; Escaped "$":  \$  produces a literal "$".
 ; In unquoted values  :  \$ → $
-; In double-quoted     :  \$ → $  (via escape-seq)
-; In single-quoted     :  \$ → \$ (literal, no processing)
+; In double-quoted    :  \$ → $  (via escape-sequence)
+; In single-quoted    :  \$ → \$ (literal, no processing)
 
 ; ============================================================
 ; A.  Processing Rules (Consumer)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -55,7 +55,7 @@ fn key<'a>(input: &mut &'a str) -> winnow::Result<&'a str> {
 
 // ---- §6 separator = *WSP "=" *WSP ----
 
-fn separator<'a>(input: &mut &'a str) -> winnow::Result<()> {
+fn separator(input: &mut &str) -> winnow::Result<()> {
     (space0, "=", space0).void().parse_next(input)
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -13,26 +13,36 @@ pub(crate) enum Value<'a> {
 
 pub(crate) type Pair<'a> = (&'a str, Value<'a>);
 
+// ---- §1 File Structure / Top-level ----
+
 pub(crate) fn parse<'a>(input: &mut &'a str) -> winnow::Result<Option<Pair<'a>>> {
     delimited(
         multispace0,
-        alt((comment.map(|_| None), kv_line.map(Some))),
+        alt((comment_line.map(|_| None), kv_line.map(Some))),
         multispace0,
     )
     .parse_next(input)
 }
 
-fn comment<'a>(input: &mut &'a str) -> winnow::Result<&'a str> {
+// ---- §3 comment-line = "#" *NON-EOL ----
+
+fn comment_line<'a>(input: &mut &'a str) -> winnow::Result<&'a str> {
     preceded("#", till_line_ending).parse_next(input)
 }
 
-fn kv_line<'a>(input: &mut &'a str) -> winnow::Result<Pair<'a>> {
-    preceded(
-        opt(("export", space1)),
-        separated_pair(key, (space0, "=", space0), value),
-    )
-    .parse_next(input)
+// ---- §4 export = "export" 1*WSP ----
+
+fn export_prefix<'a>(input: &mut &'a str) -> winnow::Result<&'a str> {
+    preceded("export", space1).parse_next(input)
 }
+
+// ---- §1 kv-line = [ export ] key separator [ value ] [ inline-comment ] ----
+
+fn kv_line<'a>(input: &mut &'a str) -> winnow::Result<Pair<'a>> {
+    preceded(opt(export_prefix), separated_pair(key, separator, value)).parse_next(input)
+}
+
+// ---- §5 key = ( ALPHA / "_" ) *( ALPHA / DIGIT / "_" ) ----
 
 fn key<'a>(input: &mut &'a str) -> winnow::Result<&'a str> {
     take_while(1.., |c: char| c.is_ascii_alphanumeric() || c == '_')
@@ -43,37 +53,50 @@ fn key<'a>(input: &mut &'a str) -> winnow::Result<&'a str> {
         .parse_next(input)
 }
 
+// ---- §6 separator = *WSP "=" *WSP ----
+
+fn separator<'a>(input: &mut &'a str) -> winnow::Result<()> {
+    (space0, "=", space0).void().parse_next(input)
+}
+
+// ---- §7 Values ----
+
 fn value<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
     if input.is_empty() {
         return Ok(Value::List(vec![]));
     }
+
     match input.as_bytes()[0] as char {
         '\'' => single_quoted.parse_next(input),
         '"' => double_quoted.parse_next(input),
         '`' => backtick_quoted.parse_next(input),
-        _ => unquoted_value.parse_next(input),
+        _ => unquoted.parse_next(input),
     }
 }
 
-fn backtick_quoted<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
-    delimited("`", take_till(0.., |c| c == '`'), "`")
-        .map(Value::Lit)
-        .parse_next(input)
-}
-
+// §7.1 single-quoted = "'" *single-char "'"
 fn single_quoted<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
     delimited("'", take_till(0.., |c| c == '\''), "'")
         .map(Value::Lit)
         .parse_next(input)
 }
 
+// §7.2 double-quoted = DQUOTE *double-char DQUOTE
 fn double_quoted<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
     let content = delimited("\"", take_till(0.., |c| c == '"'), "\"").parse_next(input)?;
     let mut content_input = content;
     expand(true).parse_next(&mut content_input)
 }
 
-fn unquoted_value<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
+// §7.3 backtick-quoted = "`" *backtick-char "`"
+fn backtick_quoted<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
+    delimited("`", take_till(0.., |c| c == '`'), "`")
+        .map(Value::Lit)
+        .parse_next(input)
+}
+
+// §7.4 unquoted = 1*unquoted-char
+fn unquoted<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
     let raw = take_till(0.., |c: char| c == '\n' || c == '\r' || c == '#')
         .map(|s: &str| s.trim())
         .parse_next(input)?;
@@ -81,21 +104,22 @@ fn unquoted_value<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
     expand(false).parse_next(&mut raw_input)
 }
 
+// ---- §7 Internal: content expander for quoted/unquoted values ----
+
 fn expand<'a>(expand_new_lines: bool) -> impl Parser<&'a str, Value<'a>, ContextError> {
     repeat(
         0..,
         alt((
             substitution,
-            escape(expand_new_lines),
+            escape_seq(expand_new_lines),
             take_till(1.., |c: char| c == '\\' || c == '$').map(Value::Lit),
         )),
     )
     .map(Value::List)
 }
 
-fn escape<'a>(expand_new_lines: bool) -> impl Parser<&'a str, Value<'a>, ContextError> {
+fn escape_seq<'a>(expand_new_lines: bool) -> impl Parser<&'a str, Value<'a>, ContextError> {
     let new_line = if expand_new_lines { "\n" } else { "\\n" };
-    // double-quoted: \n \r \\ \$; unquoted: \\ \$ only (\n handled as literal)
     preceded(
         "\\",
         one_of(if expand_new_lines {
@@ -115,22 +139,27 @@ fn escape<'a>(expand_new_lines: bool) -> impl Parser<&'a str, Value<'a>, Context
     })
 }
 
+// ---- §9 Variable Substitution ----
+
 fn substitution<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
-    alt((substitution_braces, substitution_simple)).parse_next(input)
+    alt((brace_sub, simple_sub)).parse_next(input)
 }
 
-fn substitution_simple<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
+// §9 simple-sub = "$" key
+fn simple_sub<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
     preceded("$", key)
         .map(|name| Value::Sub(name, None))
         .parse_next(input)
 }
 
-fn substitution_braces<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
+// §9 brace-sub = "${" key [ ":-" fallback ] "}"
+fn brace_sub<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
     delimited("${", (key, opt(preceded(":-", fallback))), "}")
         .map(|(name, maybe): (&str, Option<Value>)| Value::Sub(name, maybe.map(Box::new)))
         .parse_next(input)
 }
 
+// §9 fallback = *( substitution / fallback-text )
 fn fallback<'a>(input: &mut &'a str) -> winnow::Result<Value<'a>> {
     repeat(
         0..,


### PR DESCRIPTION
## Summary

- Rename ABNF rules to `-quoted` naming scheme, `separator`, `escape-sequence`
- Update `src/parse.rs` functions to match ABNF names (`simple_sub`, `brace_sub`, `escape_seq`, `comment_line`, `unquoted`, etc.)
- Extract `export_prefix` and `separator` as named parsers
- Reorder code to follow ABNF § numbering

## Changes

- `spec/dotenv.abnf` — naming unification across all rules
- `src/parse.rs` — rename + restructure to mirror ABNF, zero logic changes